### PR TITLE
feat: store position id between runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ Default: ./history.json
 The uniswapv3 pool configuration. This is encoded as `<token0address>:<token1address>:<fee>`
 Default: 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48:3000 (USDC:WETH 3%)
 
-
 ## Usage
 
 ```sh

--- a/src/swap.ts
+++ b/src/swap.ts
@@ -102,8 +102,9 @@ export class SwapManager {
       data: params.calldata,
       value: params.value,
       gasPrice: await getFastGasPrice(),
+      gasLimit: 300000,
     });
-    await tx.wait();
+    await tx.wait(3);
   }
 
   async getBalance(address: string, token: string): Promise<BigNumber> {


### PR DESCRIPTION
This commit stores the position id between runs so we can simply fetch
the chain for the specific active position instead of looping through
all positions every time. This saves a lot of eth_calls after the
initial setup phase, especially as the number of positions grows